### PR TITLE
Extending notifications

### DIFF
--- a/app/src/androidTest/java/com/skysphere/skysphere/HomePageFragmentTest.kt
+++ b/app/src/androidTest/java/com/skysphere/skysphere/HomePageFragmentTest.kt
@@ -79,7 +79,7 @@ class HomePageFragmentTest {
         Thread.sleep(1000)
 
         // Check if the last refresh time has changed
-        onView(withId(R.id.lastRefreshTextView)).check(matches(not(withText(initialRefreshTime))))
+        onView(withId(R.id.tvLastUpdated)).check(matches(not(withText(initialRefreshTime))))
     }
 
 
@@ -95,7 +95,7 @@ class HomePageFragmentTest {
     // Helper function to get the current last refresh time
     private fun getLastRefreshTime(): String {
         var refreshTime = ""
-        onView(withId(R.id.lastRefreshTextView)).check { view, _ ->
+        onView(withId(R.id.tvLastUpdated)).check { view, _ ->
             refreshTime = (view as TextView).text.toString()
         }
         return refreshTime

--- a/app/src/main/java/com/skysphere/skysphere/WeatherViewModel.kt
+++ b/app/src/main/java/com/skysphere/skysphere/WeatherViewModel.kt
@@ -30,6 +30,7 @@ private val repository: WeatherRepository
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     fun getData(): WeatherResults? {
         return repository.getWeatherDataFromDatabase()
     }

--- a/app/src/main/java/com/skysphere/skysphere/data/SettingsManager.kt
+++ b/app/src/main/java/com/skysphere/skysphere/data/SettingsManager.kt
@@ -71,9 +71,9 @@ class SettingsManager @Inject constructor(
     }
 
     // Saving the preference for the severe weather warnings notification of the user
-    fun saveNotificationPreference(enabled: Boolean) {
+    fun saveNotificationPreference(key: String, enabled: Boolean,) {
         val editor = appPreferences.edit()
-        editor.putBoolean(SEVERE_NOTIFICATION_PREFERENCE_KEY, enabled)
+        editor.putBoolean(key, enabled)
         editor.apply()
     }
 

--- a/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.skysphere.skysphere.API.WeatherType
 import com.skysphere.skysphere.MainActivity
 import com.skysphere.skysphere.R
 
@@ -18,7 +19,7 @@ object NotificationManager {
     private const val DAILY_SUMMARY_NOTIFICATION_ID = 3
 
     // Function to show a severe weather notification
-    fun showSevereWeatherNotification(context: Context) {
+    fun showSevereWeatherNotification(context: Context, weatherCode: Int?) {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         // Create the notification channel for severe weather alerts
@@ -41,7 +42,7 @@ object NotificationManager {
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle("Severe Weather Alert")
-            .setContentText("Severe weather conditions expected. Tap for more information.")
+            .setContentText("Severe weather conditions: ${WeatherType.fromWMO(weatherCode).weatherDesc} are expected. Tap for more information.")
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
@@ -49,4 +50,39 @@ object NotificationManager {
 
         notificationManager.notify(SEVERE_WEATHER_NOTIFICATION_ID, notification)
     }
+
+    // Function to show the rain forecast notification
+
+    fun showRainForecastNotification(context: Context, time: Pair<Int?, String>) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Create the notification channel for rain forecast notifications
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Rain Forecast Notification",
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        // Create the intent for the rain forecast notification
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+        // Build and show the severe weather notification
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Current Rain Forecast")
+            .setContentText("${WeatherType.fromWMO(time.first).weatherDesc} is expected at ${time.second}. Tap for more information.")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(RAIN_FORECAST_NOTIFICATION_ID, notification)
+    }
+
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
@@ -10,6 +10,7 @@ import androidx.core.app.NotificationCompat
 import com.skysphere.skysphere.API.WeatherType
 import com.skysphere.skysphere.MainActivity
 import com.skysphere.skysphere.R
+import com.skysphere.skysphere.data.weather.WeatherResults
 
 object NotificationManager {
     // Including the channel id and notification id here
@@ -83,6 +84,45 @@ object NotificationManager {
             .build()
 
         notificationManager.notify(RAIN_FORECAST_NOTIFICATION_ID, notification)
+    }
+
+    fun showDailySummaryNotification(context: Context, weatherResults: WeatherResults?) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Create the notification channel for daily notifications
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Daily Weather Summary",
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        // Create the intent for the severe weather notification
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+        // Build and show the severe weather notification
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Daily Weather Summary")
+            .setContentText("Expand to view.")
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText("Current temperature is ${weatherResults?.current?.temperature}, " +
+                        "feels like ${weatherResults?.current?.apparentTemperature}. " +
+                        "High today is ${weatherResults?.daily?.temperatureMax?.get(0)}, " +
+                        "Low today is ${weatherResults?.daily?.temperatureMax?.get(0)}. " +
+                        "Conditions today will be mostly ${WeatherType.fromWMO(weatherResults?.daily?.weatherCode?.get(0)).weatherDesc}. " +
+                        "Tap for more information "))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(DAILY_SUMMARY_NOTIFICATION_ID, notification)
     }
 
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/NotificationManager.kt
@@ -12,8 +12,10 @@ import com.skysphere.skysphere.R
 
 object NotificationManager {
     // Including the channel id and notification id here
-    private const val CHANNEL_ID = "severe_weather_channel"
-    private const val NOTIFICATION_ID = 1
+    private const val CHANNEL_ID = "weather_channel"
+    private const val SEVERE_WEATHER_NOTIFICATION_ID = 1
+    private const val RAIN_FORECAST_NOTIFICATION_ID = 2
+    private const val DAILY_SUMMARY_NOTIFICATION_ID = 3
 
     // Function to show a severe weather notification
     fun showSevereWeatherNotification(context: Context) {
@@ -45,6 +47,6 @@ object NotificationManager {
             .setAutoCancel(true)
             .build()
 
-        notificationManager.notify(NOTIFICATION_ID, notification)
+        notificationManager.notify(SEVERE_WEATHER_NOTIFICATION_ID, notification)
     }
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -69,7 +69,7 @@ class WeatherCheckWorker @AssistedInject constructor(
 
     // Check if the weather code is one of the severe codes.
     private fun isSevereWeather(weatherData: WeatherResults?): Boolean {
-        val severeWeatherCodes = listOf(95, 96, 99) // Thunderstorm codes
+        val severeWeatherCodes = listOf(95, 96, 99, 0, 1, 2, 3) // Thunderstorm codes
         return weatherData?.current?.weatherCode in severeWeatherCodes
     }
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -51,7 +51,12 @@ class WeatherCheckWorker @AssistedInject constructor(
 
     // Check if the weather code is one of the severe codes.
     private fun isSevereWeather(weatherData: WeatherResults?): Boolean {
+
+        /* Production code (REVERT BACK TO THIS AFTER TESTING)
         val severeWeatherCodes = listOf(95, 96, 99) // Thunderstorm codes
         return weatherData?.current?.weatherCode in severeWeatherCodes
+        */
+        return weatherData?.current?.weatherCode in listOf(0, 1, 2, 3)
+
     }
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -30,6 +30,7 @@ class WeatherCheckWorker @AssistedInject constructor(
 
 
     private var lastRainForecastTimestamp = LocalDateTime.now()
+    private var hasDailyBeenSent = false
 
 
 
@@ -53,6 +54,16 @@ class WeatherCheckWorker @AssistedInject constructor(
                NotificationManager.showRainForecastNotification(applicationContext, rainForecast)
            }
 
+           // If the daily summary has not been sent from 7:00 - 7:59 and notification is enabled, show notification
+           val currentTime = LocalDateTime.now()
+           if(currentTime.hour == 15 && isNotificationEnabled(SettingsFragment.DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY)){
+                if(!hasDailyBeenSent){
+                    NotificationManager.showDailySummaryNotification(applicationContext, weatherResults)
+                    hasDailyBeenSent = true
+                }
+           }
+
+
 
             Result.success()
         } catch (e: Exception) {
@@ -62,7 +73,7 @@ class WeatherCheckWorker @AssistedInject constructor(
 
     // Make sure that the notifications are enabled from settings.
     private fun isNotificationEnabled(key: String): Boolean {
-        return settingsManager.checkNotification(key, true)
+        return settingsManager.checkNotification(key, false)
     }
 
 
@@ -73,7 +84,7 @@ class WeatherCheckWorker @AssistedInject constructor(
         val severeWeatherCodes = listOf(95, 96, 99) // Thunderstorm codes
         return weatherData?.current?.weatherCode in severeWeatherCodes
         */
-        return weatherData?.current?.weatherCode in listOf(95, 96, 99)
+        return weatherData?.current?.weatherCode in listOf(0, 1, 2, 3)
 
     }
 

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -55,7 +55,7 @@ class WeatherCheckWorker @AssistedInject constructor(
            }
 
            // If the daily summary has not been sent from 7:00 - 7:59 and notification is enabled, show notification
-           val currentTime = LocalDateTime.now()
+           val currentTime = LocalDateTime.now() // 24 hr time
            if(currentTime.hour == 15 && isNotificationEnabled(SettingsFragment.DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY)){
                 if(!hasDailyBeenSent){
                     NotificationManager.showDailySummaryNotification(applicationContext, weatherResults)

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -7,7 +7,6 @@ import androidx.hilt.work.HiltWorker
 import androidx.lifecycle.Observer
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.skysphere.skysphere.GPSManager
 import com.skysphere.skysphere.WeatherViewModel
 import com.skysphere.skysphere.data.SettingsManager
 import com.skysphere.skysphere.data.weather.WeatherResults
@@ -40,9 +39,6 @@ class WeatherCheckWorker @AssistedInject constructor(
         viewModel.weatherResults.observeForever(observer)
 
         try {
-            // Get the current location
-            val gpsManager = GPSManager(applicationContext)
-
             // Trigger fetching weather data
             viewModel.fetchWeatherData() // This will update the LiveData
 

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -30,7 +30,7 @@ class WeatherCheckWorker @AssistedInject constructor(
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
        try {
            // Initialize weather results directly from viewModel
-           val weatherResults = viewModel.getData()
+           weatherResults = viewModel.getData()
 
            // If the weather code is severe and notifications are enabled, show notification
            if (isSevereWeather(weatherResults) && isNotificationEnabled()) {

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherCheckWorker.kt
@@ -14,6 +14,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import android.util.Log
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.math.log
 
 @HiltWorker
 @RequiresApi(Build.VERSION_CODES.O)
@@ -25,6 +29,10 @@ class WeatherCheckWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, params) {
 
 
+    private var lastRainForecastTimestamp = LocalDateTime.now()
+
+
+
     private var weatherResults: WeatherResults? = null
     // Fetch weather data and check if it's severe, sending a notification if it is
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
@@ -32,10 +40,19 @@ class WeatherCheckWorker @AssistedInject constructor(
            // Initialize weather results directly from viewModel
            weatherResults = viewModel.getData()
 
-           // If the weather code is severe and notifications are enabled, show notification
-           if (isSevereWeather(weatherResults) && isNotificationEnabled()) {
-               NotificationManager.showSevereWeatherNotification(applicationContext)
+           // If the weather code is severe (thunderstorm) and notification is enabled, show notification
+           if (isSevereWeather(weatherResults) && isNotificationEnabled(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY)) {
+               NotificationManager.showSevereWeatherNotification(applicationContext,
+                   weatherResults?.current?.weatherCode
+               )
            }
+
+           // If the rain forecast is not null (rain forecasted) and notification is enabled, show notification
+           val rainForecast = checkRainForecast(weatherResults)
+           if (rainForecast != null && isNotificationEnabled(SettingsFragment.RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY)) {
+               NotificationManager.showRainForecastNotification(applicationContext, rainForecast)
+           }
+
 
             Result.success()
         } catch (e: Exception) {
@@ -44,8 +61,8 @@ class WeatherCheckWorker @AssistedInject constructor(
     }
 
     // Make sure that the notifications are enabled from settings.
-    private fun isNotificationEnabled(): Boolean {
-        return settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
+    private fun isNotificationEnabled(key: String): Boolean {
+        return settingsManager.checkNotification(key, true)
     }
 
 
@@ -56,7 +73,49 @@ class WeatherCheckWorker @AssistedInject constructor(
         val severeWeatherCodes = listOf(95, 96, 99) // Thunderstorm codes
         return weatherData?.current?.weatherCode in severeWeatherCodes
         */
-        return weatherData?.current?.weatherCode in listOf(0, 1, 2, 3)
+        return weatherData?.current?.weatherCode in listOf(95, 96, 99)
 
+    }
+
+    private fun checkRainForecast(weatherData: WeatherResults?): Pair<Int?, String>? {
+        val hourlyCodes = weatherData?.hourly?.weatherCode?.take(24) // 24 hours of the day
+        val hourlyTimes = weatherData?.hourly?.time?.take(24) // 24 hours of the day
+
+        val rainCodes = listOf(0, 1, 2, 3) // rain codes (DUMMY VALUES FOR TESTING)
+
+        // Current time in ISO 8601 format to compare against
+        val currentTime = LocalDateTime.now()
+
+        // Go through the hourly weather data
+        if (hourlyCodes != null && hourlyTimes != null) {
+            for (i in hourlyCodes.indices) {
+                // Convert each hourly timestamp into LocalDateTime for comparison
+                val hourlyTime = LocalDateTime.parse(hourlyTimes[i], DateTimeFormatter.ISO_DATE_TIME)
+
+                // Only consider future hours and non-duplicate timestamps of rain
+                if (hourlyTime.isAfter(currentTime) && !hourlyTime.equals(lastRainForecastTimestamp)) {
+                    // Check if the weather code corresponds to rain
+                    if (hourlyCodes[i] in rainCodes) {
+                        lastRainForecastTimestamp = hourlyTime // Update the last rain forecast timestamp
+                        return Pair(hourlyCodes[i], convertToSimpleTime(hourlyTime.toString())) // Return the weather code and hour
+                    }
+                }
+            }
+        }
+
+        return null // No rain found in future hours
+    }
+
+    // Helper function for converting ISO 8601 timestamp to a readable time
+
+    fun convertToSimpleTime(isoTimestamp: String): String {
+        // Parse the ISO 8601 timestamp to a LocalDateTime object
+        val dateTime = LocalDateTime.parse(isoTimestamp, DateTimeFormatter.ISO_DATE_TIME)
+
+        // Define a formatter to convert the time to a readable format like "3:00 PM"
+        val formatter = DateTimeFormatter.ofPattern("h:mm a")
+
+        // Format the LocalDateTime object to the desired time format
+        return dateTime.format(formatter)
     }
 }

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
@@ -43,11 +43,12 @@ class WeatherService : Service() {
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 
-        // Check to make sure user has either severe or rain notifications enabled
-        val forSevere = settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
-        val forRain = settingsManager.checkNotification(SettingsFragment.RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, true)
+        // Check to make sure user has any type of notification selected
+        val forSevere = settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, false)
+        val forRain = settingsManager.checkNotification(SettingsFragment.RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, false)
+        val forDaily = settingsManager.checkNotification(SettingsFragment.DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY, false)
 
-        if (forSevere || forRain) {
+        if (forSevere || forRain || forDaily) {
             scheduleWeatherCheck()
         } else {
             cancelWeatherCheck()

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
@@ -3,7 +3,9 @@ package com.skysphere.skysphere.notifications
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
+import androidx.annotation.RequiresApi
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -37,6 +39,7 @@ class WeatherService : Service() {
 
     // Including the onCreate function here, if notifications are enabled, start the worker
     // If they are disabled, cancel the worker if it was ever running.
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val isNotificationEnabled = settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
 

--- a/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
+++ b/app/src/main/java/com/skysphere/skysphere/notifications/WeatherService.kt
@@ -3,8 +3,10 @@ package com.skysphere.skysphere.notifications
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -38,16 +40,19 @@ class WeatherService : Service() {
 
     // Including the onCreate function here, if notifications are enabled, start the worker
     // If they are disabled, cancel the worker if it was ever running.
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val isNotificationEnabled = settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
 
-        if (isNotificationEnabled) {
+        // Check to make sure user has either severe or rain notifications enabled
+        val forSevere = settingsManager.checkNotification(SettingsFragment.SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
+        val forRain = settingsManager.checkNotification(SettingsFragment.RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, true)
+
+        if (forSevere || forRain) {
             scheduleWeatherCheck()
         } else {
             cancelWeatherCheck()
             stopSelf()
         }
-
         return START_STICKY
     }
 

--- a/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
@@ -41,7 +41,7 @@ class SettingsFragment : Fragment() {
     companion object {
         const val SEVERE_NOTIFICATION_PREFERENCE_KEY = "severe_notification_preference"
         const val RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY = "rain_forecast_notification_preference"
-        const val DAILY_SUMMARY_PREFERENCE_KEY = "daily_summary_notification_preference"
+        const val DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY = "daily_summary_notification_preference"
     }
 
     // Declared the views that have been created in the XML files
@@ -308,14 +308,15 @@ class SettingsFragment : Fragment() {
 
         // Determining the checked state of the daily summary notification preference (off by default)
         dailySummaryCheckBox.isChecked =
-            settingsManager.checkNotification(DAILY_SUMMARY_PREFERENCE_KEY, false)
+            settingsManager.checkNotification(DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY, false)
 
         // Setting up the listener for the daily summary checkbox
         dailySummaryCheckBox.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
                 if (checkNotificationPermission()) {
-                    settingsManager.saveNotificationPreference(DAILY_SUMMARY_PREFERENCE_KEY, true)
-                    // TODO enable daily summary notifications
+                    settingsManager.saveNotificationPreference(
+                        DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY, true)
+                    WeatherService.startWeatherMonitoring(requireContext())
                 } else {
                     // Uncheck the box if permission is not granted
                     dailySummaryCheckBox.isChecked = false
@@ -326,8 +327,8 @@ class SettingsFragment : Fragment() {
                     ).show()
                 }
             } else {
-                settingsManager.saveNotificationPreference(DAILY_SUMMARY_PREFERENCE_KEY, false)
-                // TODO disable daily summary notifications
+                settingsManager.saveNotificationPreference(DAILY_SUMMARY_NOTIFICATION_PREFERENCE_KEY, false)
+                WeatherService.stopWeatherMonitoring(requireContext())
             }
         }
 

--- a/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
@@ -40,6 +40,8 @@ class SettingsFragment : Fragment() {
     // Object for severe notification preference key, needed for the notification functionality
     companion object {
         const val SEVERE_NOTIFICATION_PREFERENCE_KEY = "severe_notification_preference"
+        const val RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY = "rain_forecast_notification_preference"
+        const val DAILY_SUMMARY_PREFERENCE_KEY = "daily_summary_notification_preference"
     }
 
     // Declared the views that have been created in the XML files
@@ -80,6 +82,8 @@ class SettingsFragment : Fragment() {
         val ttsCard: CardView = view.findViewById(R.id.ttsCard)
         val visibilityCard: CardView = view.findViewById(R.id.visibilityCard)
         val severeWeatherWarningCheckBox: CheckBox = view.findViewById(R.id.severe_weather_warnings)
+        val rainForecastCheckBox: CheckBox = view.findViewById(R.id.rain_notifications)
+        val dailySummaryCheckBox: CheckBox = view.findViewById(R.id.daily_summary)
 
         // Assigning the views
         temperatureUnitTextView = view.findViewById(R.id.temp_details)
@@ -251,6 +255,32 @@ class SettingsFragment : Fragment() {
             dialog.show()
         }
 
+        // Determining the checked state of the rain forecast notification preference (off by default)
+        rainForecastCheckBox.isChecked =
+            settingsManager.checkNotification(RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, false)
+
+        // Setting up the listener for the rain forecast notification checkbox
+        rainForecastCheckBox.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                if (checkNotificationPermission()) {
+                    settingsManager.saveNotificationPreference(
+                        RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, true)
+                    // TODO enable rain forecast notifications
+                } else {
+                    // Uncheck the box if permission is not granted
+                    rainForecastCheckBox.isChecked = false
+                    Toast.makeText(
+                        context,
+                        "Notification permission is required for rain forecast notifications",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            } else {
+                settingsManager.saveNotificationPreference(RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, false)
+                // TODO disable rain forecast notifications
+            }
+        }
+
         // Determining the checked state of the weather warnings notification preference (off by default)
         severeWeatherWarningCheckBox.isChecked =
             settingsManager.checkNotification(SEVERE_NOTIFICATION_PREFERENCE_KEY, false)
@@ -259,7 +289,7 @@ class SettingsFragment : Fragment() {
         severeWeatherWarningCheckBox.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked) {
                 if (checkNotificationPermission()) {
-                    settingsManager.saveNotificationPreference(true)
+                    settingsManager.saveNotificationPreference(SEVERE_NOTIFICATION_PREFERENCE_KEY, true)
                     WeatherService.startWeatherMonitoring(requireContext())
                 } else {
                     // Uncheck the box if permission is not granted
@@ -271,8 +301,33 @@ class SettingsFragment : Fragment() {
                     ).show()
                 }
             } else {
-                settingsManager.saveNotificationPreference(false)
+                settingsManager.saveNotificationPreference(SEVERE_NOTIFICATION_PREFERENCE_KEY, false)
                 WeatherService.stopWeatherMonitoring(requireContext())
+            }
+        }
+
+        // Determining the checked state of the daily summary notification preference (off by default)
+        dailySummaryCheckBox.isChecked =
+            settingsManager.checkNotification(DAILY_SUMMARY_PREFERENCE_KEY, false)
+
+        // Setting up the listener for the daily summary checkbox
+        dailySummaryCheckBox.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked) {
+                if (checkNotificationPermission()) {
+                    settingsManager.saveNotificationPreference(DAILY_SUMMARY_PREFERENCE_KEY, true)
+                    // TODO enable daily summary notifications
+                } else {
+                    // Uncheck the box if permission is not granted
+                    dailySummaryCheckBox.isChecked = false
+                    Toast.makeText(
+                        context,
+                        "Notification permission is required for daily summary notifications",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            } else {
+                settingsManager.saveNotificationPreference(DAILY_SUMMARY_PREFERENCE_KEY, false)
+                // TODO disable daily summary notifications
             }
         }
 

--- a/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/skysphere/skysphere/ui/settings/SettingsFragment.kt
@@ -265,7 +265,7 @@ class SettingsFragment : Fragment() {
                 if (checkNotificationPermission()) {
                     settingsManager.saveNotificationPreference(
                         RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, true)
-                    // TODO enable rain forecast notifications
+                    WeatherService.startWeatherMonitoring(requireContext())
                 } else {
                     // Uncheck the box if permission is not granted
                     rainForecastCheckBox.isChecked = false
@@ -277,7 +277,7 @@ class SettingsFragment : Fragment() {
                 }
             } else {
                 settingsManager.saveNotificationPreference(RAIN_FORECAST_NOTIFICATION_PREFERENCE_KEY, false)
-                // TODO disable rain forecast notifications
+                WeatherService.stopWeatherMonitoring(requireContext())
             }
         }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -331,11 +331,11 @@
                 app:layout_constraintStart_toStartOf="parent" />
 
             <CheckBox
-                android:id="@+id/weather_refresh"
+                android:id="@+id/rain_notifications"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
-                android:text="@string/Weather_Refresh"
+                android:text="@string/Rain_Notification"
                 android:textColor="@color/black"
                 app:layout_constraintStart_toStartOf="@id/text_Notifications"
                 app:layout_constraintTop_toBottomOf="@id/text_Notifications" />
@@ -346,17 +346,8 @@
                 android:layout_height="wrap_content"
                 android:text="@string/Severe_Weather_Warnings"
                 android:textColor="@color/black"
-                app:layout_constraintStart_toStartOf="@id/weather_refresh"
-                app:layout_constraintTop_toBottomOf="@id/weather_refresh" />
-
-            <CheckBox
-                android:id="@+id/rain_alerts"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/Rain_Alerts"
-                android:textColor="@color/black"
-                app:layout_constraintStart_toStartOf="@id/severe_weather_warnings"
-                app:layout_constraintTop_toBottomOf="@id/severe_weather_warnings" />
+                app:layout_constraintStart_toStartOf="@id/rain_notifications"
+                app:layout_constraintTop_toBottomOf="@id/rain_notifications" />
 
             <CheckBox
                 android:id="@+id/daily_summary"
@@ -364,8 +355,9 @@
                 android:layout_height="wrap_content"
                 android:text="@string/Daily_Summary"
                 android:textColor="@color/black"
-                app:layout_constraintStart_toStartOf="@id/rain_alerts"
-                app:layout_constraintTop_toBottomOf="@id/rain_alerts" />
+                app:layout_constraintStart_toStartOf="@id/severe_weather_warnings"
+                app:layout_constraintTop_toBottomOf="@id/severe_weather_warnings" />
+
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,10 +24,9 @@
     <string name="Millimeters">mm</string>
     <string name="Inches">in</string>
     <string name="Notifications">Notifications</string>
-    <string name="Weather_Refresh">Weather Refresh</string>
+    <string name="Rain_Notification">Rain Notifications [Currently Unavailable]</string>
     <string name="Severe_Weather_Warnings">Severe Weather Warnings</string>
-    <string name="Rain_Alerts">Rain Alerts</string>
-    <string name="Daily_Summary">Daily Summary</string>
+    <string name="Daily_Summary">Daily Summary [Currently Unavailable]</string>
     <string name="menu_home">Home</string>
     <string name="FeelsLikeTemperature">Feels Like Temperature</string>
     <string name="menu_locations">Locations</string>


### PR DESCRIPTION
There are now 3 separate dynamic notifications that a user can receive.

A user can receive updates about rain, telling them what time the nearest instance of rain will occur,
A user can receive updates about severe weather warnings (currently only thunderstorms implemented but it is only a small change to include other severe alerts).
A user can receive a daily weather summary notification sent to their device at 7am for a quick morning weather brief.

All notifications can be adapted to display any kind of weather data we choose, although notification and work manager must be updated with the data required.